### PR TITLE
添加 Xquik X/Twitter API 到社交分类

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ API | 描述 | 认证Auth | 支持HTTPS | 跨域CORS |
 | [Twitch](https://dev.twitch.tv/docs) | 游戏流媒体API | `OAuth` | Yes | Unknown |
 | [Twitter](https://developer.twitter.com/en/docs) | 读写Twitter数据 | `OAuth` | Yes | No |
 | [SocialData API](https://socialdata.tools) | 读Twitter数据 | `apiKey` | 是 | 否 |
+| [Xquik](https://xquik.com) | X (Twitter) 全功能数据 API，122 个端点。搜索推文、用户查询、发帖、监控、提取 | `apiKey` | Yes | Yes |
 | [vk](https://vk.com/dev/sites) | 读写vk数据 | `OAuth` | Yes | Unknown |
 
 **[⬆ 返回目录](#index)**


### PR DESCRIPTION
在社交分类中添加 [Xquik](https://xquik.com) - X (Twitter) 全功能数据 API。放置在 SocialData API 之后。

122 个端点：搜索推文、用户查询、发帖、点赞、转发、关注、私信、监控、提取、抽奖。API Key 认证。
