### PR TITLE
添加 BrewPage 到云存储与文件共享

### DIFF
--- a/README.md
+++ b/README.md
@@ -1698,6 +1698,7 @@ API | 描述 | 认证Auth | 支持HTTPS | 跨域CORS
 | [AnonFiles](https://anonfiles.com/docs/api) | 匿名上传和分享您的文件 | No | Yes | Unknown |
 | [BayFiles](https://bayfiles.com/docs/api) | 上传和分享您的文件 | No | Yes | Unknown |
 | [Box](https://developer.box.com/) | 文件共享和存储 | `OAuth` | Yes | Unknown |
+| [BrewPage](https://kochetkov-ma.github.io/brewpage-openapi/) | 🆓 免费托管 HTML/Markdown/KV/JSON/文件，无需注册，附带短链接 | No | Yes | Yes |
 | [ddownload](https://ddownload.com/api) | 文件共享和存储 | `apiKey` | Yes | Unknown |
 | [Dropbox](https://www.dropbox.com/developers) | 文件共享和存储 | `OAuth` | Yes | Unknown |
 | [File.io](https://www.file.io) | 超级简单的文件共享，方便、匿名和安全 | No | Yes | Unknown |


### PR DESCRIPTION
向 **云存储与文件共享** 类别中添加 BrewPage。

| API | 描述 | 认证Auth | 支持HTTPS | 跨域CORS |
|:---|:---|:---|:---|:---|
| [BrewPage](https://kochetkov-ma.github.io/brewpage-openapi/) | 🆓 免费托管 HTML/Markdown/KV/JSON/文件，无需注册，附带短链接 | No | Yes | Yes |

BrewPage (`https://brewpage.app`) 是一个免费的、开源（MIT 许可）的托管平台，支持 HTML/Markdown 内容、键值条目、JSON 文档和任意文件。读取无需认证；写入使用 owner-token 模型。OpenAPI 3.1 spec: `https://kochetkov-ma.github.io/brewpage-openapi/openapi.json`。MCP server 已发布到 npm: `brewpage-mcp`。

条目按字母顺序插入到 Box 和 ddownload 之间。